### PR TITLE
Make use of the trigger for non Pro Classic Controller

### DIFF
--- a/examples/classic_controller_simpletest.py
+++ b/examples/classic_controller_simpletest.py
@@ -17,6 +17,11 @@ while True:
     if (joysticks.lx, joysticks.ly) != (32, 32):
         print("Left joystick = {},{}".format(joysticks.lx, joysticks.ly))
 
+    # triggers when not pressed is at (0,0)
+    # Classic Controler Pro as no potentiometer and only report 0 or 31
+    if (triggers.left, triggers.right) != (0, 0):
+        print("Trigger left and right = {},{}".format(triggers.left, triggers.right))
+        
     if buttons.A:
         print("button A")
     if buttons.B:


### PR DESCRIPTION
On my controller that is a Pro, there is no interest in getting the trigger value as it is 0 or 31 (for backward compatibility) and give the same information as button L and R.